### PR TITLE
added gdsl so idea recognizes bound variables in plugin.groovy

### DIFF
--- a/src_groovy/intellijeval/pluginScriptCompletions.gdsl
+++ b/src_groovy/intellijeval/pluginScriptCompletions.gdsl
@@ -1,0 +1,17 @@
+package intellijeval
+/**
+ * Created with IntelliJ IDEA.
+ * User: jason
+ * Date: 2/5/13
+ * Time: 3:28 PM
+ * To change this template use File | Settings | File Templates.
+ */
+
+def ctx = context(scope: scriptScope(),pathRegexp:'.*plugin\\.groovy$')
+
+contributor(ctx) {
+    property name: 'event', type: 'com.intellij.openapi.actionSystem.AnActionEvent'
+    property name: 'project', type: 'com.intellij.openapi.project.Project'
+    property name: 'isIdeStartup', type: Boolean.name
+    property name: 'pluginPath', type: String.name
+}


### PR DESCRIPTION
it's pretty basic but if added to the current project's classpath intellij will properly recognize 'event','project','isIdeStartup', and 'pluginPath' in plugin.groovy files
