### PR TITLE
#transformSelectionIn 

### DIFF
--- a/src_groovy/intellijeval/PluginUtil.groovy
+++ b/src_groovy/intellijeval/PluginUtil.groovy
@@ -637,7 +637,9 @@ class PluginUtil {
 				}
 
 				editor.document.replaceString(blockStarts[i] + plusOffset, blockEnds[i] + plusOffset, newTextPart)
-				plusOffset += newTextPart.length() - textParts[i].length()
+
+				def realTextLength = blockEnds[i] - blockStarts[i]
+				plusOffset += newTextPart.length() - realTextLength
 			}
 		} else {
 			String transformedText = textParts.collect{ transformer(it) }.join("\n")


### PR DESCRIPTION
 fixed offset calculation - texpart contains whitespace when selection reaches after end of line, but block coordinates are accurate
