### PR TITLE
Report all exceptions on load

### DIFF
--- a/src/main/liveplugin/pluginrunner/RunPluginAction.kt
+++ b/src/main/liveplugin/pluginrunner/RunPluginAction.kt
@@ -91,7 +91,7 @@ fun runPlugins(
                 bindingByPluginId[pluginId] = binding
 
                 pluginRunner.runPlugin(pluginFolder, pluginId, binding, ::runOnEdt)
-            } catch (e: Error) {
+            } catch (e: Throwable) {
                 errorReporter.addLoadingError(pluginId, e)
             } finally {
                 errorReporter.reportAllErrors { title, message -> IdeUtil.displayError(title, message, project) }


### PR DESCRIPTION
Had some class loader issues when playing around with building the plugin against 2018.3
I noticed some exceptions errors didn't get displayed by LivePlugin, so I broadened the catch clause.