### PR TITLE
Fix PluginUtil.inspect: no method named ObjectInspector.inspect

### DIFF
--- a/src/plugin-util-groovy/liveplugin/PluginUtil.groovy
+++ b/src/plugin-util-groovy/liveplugin/PluginUtil.groovy
@@ -538,7 +538,7 @@ class PluginUtil {
 	@CanCallFromAnyThread
 	static void inspect(Object object) {
 		invokeOnEDT {
-			ObjectInspector.inspect(object)
+			ObjectInspector.showPopup(object)
 		}
 	}
 


### PR DESCRIPTION
There's no method called inspect on ObjectInspector.