### PR TITLE
Fix exception thrown at startup in WebStorm due to missing icon

### DIFF
--- a/src/main/liveplugin/IdeUtil.kt
+++ b/src/main/liveplugin/IdeUtil.kt
@@ -28,6 +28,7 @@ import com.intellij.openapi.ui.Messages.showOkCancelDialog
 import com.intellij.openapi.util.IconLoader
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.util.ReflectionUtil
 import com.intellij.util.containers.ContainerUtil.map
 import com.intellij.util.download.DownloadableFileService
 import com.intellij.util.text.CharArrayUtil
@@ -243,8 +244,15 @@ object IdeUtil {
         companion object {
             internal val instance: FileType = KotlinScriptFileType()
 
+            // The kotlin icon is missing in some IDEs like WebStorm, so it's important
+            // to set `strict` to false in findIcon, so an exception won't be thrown.
+            private fun findIconOrNull(path: String) : Icon? {
+                val callerClass = ReflectionUtil.getGrandCallerClass() ?: return null
+                return IconLoader.findIcon(path, callerClass, false, false)
+            }
+
             private val kotlinScriptIcon by lazy {
-                IconLoader.findIcon("/org/jetbrains/kotlin/idea/icons/kotlin_file.png") ?: AllIcons.FileTypes.Text
+                findIconOrNull("/org/jetbrains/kotlin/idea/icons/kotlin_file.png") ?: AllIcons.FileTypes.Text
             }
         }
     }


### PR DESCRIPTION
The exception looked like this:

```
Caused by: java.lang.RuntimeException: Can't find icon in '/org/jetbrains/kotlin/idea/icons/kotlin_file.png' near class liveplugin.IdeUtil$KotlinScriptFileType$Companion$kotlinScriptIcon$2
	at com.intellij.openapi.util.IconLoader.findIcon(IconLoader.java:191)
	at com.intellij.openapi.util.IconLoader.findIcon(IconLoader.java:176)
	at com.intellij.openapi.util.IconLoader.findIcon(IconLoader.java:171)
	at com.intellij.openapi.util.IconLoader.findIcon(IconLoader.java:138)
	at liveplugin.IdeUtil$KotlinScriptFileType$Companion$kotlinScriptIcon$2.invoke(IdeUtil.kt:247)
	at liveplugin.IdeUtil$KotlinScriptFileType$Companion$kotlinScriptIcon$2.invoke(IdeUtil.kt:243)
	at kotlin.SynchronizedLazyImpl.getValue(Lazy.kt:131)
	at liveplugin.IdeUtil$KotlinScriptFileType$Companion.getKotlinScriptIcon(IdeUtil.kt)
	at liveplugin.IdeUtil$KotlinScriptFileType$Companion.access$getKotlinScriptIcon$p(IdeUtil.kt:243)
	at liveplugin.IdeUtil$KotlinScriptFileType.getIcon(IdeUtil.kt:238)
	at liveplugin.toolwindow.popup.NewFileAction.<init>(NewFileAction.java:36)
	at liveplugin.toolwindow.popup.NewKotlinFileAction.<init>(new-element-actions.kt:21)
	... 22 more
```

(also reported at https://github.com/dkandalov/live-plugin/issues/81#issuecomment-388404074)

