### PR TITLE
Fixed project plugins reading in multi-module project

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -79,6 +79,7 @@
 		<usageTypeProvider implementation="liveplugin.implementation.FindUsageInLivePlugin$UsageTypeExtension" order="last"/>
 		<useScopeEnlarger implementation="liveplugin.implementation.FindUsageInLivePlugin$UseScopeExtension"/>
         <createDirectoryCompletionContributor implementation="liveplugin.implementation.LivePluginDirectoryCompletionContributor"/>
+		<postStartupActivity implementation="liveplugin.implementation.LivePluginProjectPostStartupActivity"/>
 		<intentionAction>
             <className>liveplugin.implementation.pluginrunner.AddToClassPathGroovyIntention</className>
             <language>Groovy</language>

--- a/src/main/liveplugin/implementation/LivePluginProjectListener.kt
+++ b/src/main/liveplugin/implementation/LivePluginProjectListener.kt
@@ -1,41 +1,11 @@
 package liveplugin.implementation
 
-import com.intellij.ide.impl.isTrusted
-import com.intellij.notification.NotificationType.INFORMATION
-import com.intellij.openapi.actionSystem.ActionManager
-import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.actionSystem.CommonDataKeys
-import com.intellij.openapi.actionSystem.Presentation
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManagerListener
-import liveplugin.implementation.LivePluginPaths.livePluginsProjectDirName
-import liveplugin.implementation.common.MapDataContext
-import liveplugin.implementation.common.livePluginNotificationGroup
-import liveplugin.implementation.common.toFilePath
-import liveplugin.implementation.pluginrunner.PluginRunner.Companion.runPlugins
 import liveplugin.implementation.pluginrunner.PluginRunner.Companion.unloadPlugins
 
 class LivePluginProjectListener : ProjectManagerListener {
-    override fun projectOpened(project: Project) {
-        if (!Settings.instance.runProjectSpecificPlugins) return
-        @Suppress("UnstableApiUsage")
-        if (!project.isTrusted()) {
-            val message = "Skipped execution of project specific plugins because the project is not trusted."
-            livePluginNotificationGroup.createNotification(title = "Live plugin", message, INFORMATION).notify(project)
-            return
-        }
-
-        val dataContext = MapDataContext(mapOf(CommonDataKeys.PROJECT.name to project))
-        val dummyEvent = AnActionEvent(null, dataContext, "", Presentation(), ActionManager.getInstance(), 0)
-        runPlugins(livePluginsIn(project), dummyEvent)
-    }
-
     override fun projectClosing(project: Project) {
-        unloadPlugins(livePluginsIn(project))
-    }
-
-    private fun livePluginsIn(project: Project): List<LivePlugin> {
-        val projectPath = project.basePath?.toFilePath() ?: return emptyList()
-        return (projectPath + livePluginsProjectDirName).listFiles().toLivePlugins()
+        unloadPlugins(readLivePlugins(project))
     }
 }

--- a/src/main/liveplugin/implementation/LivePluginProjectListener.kt
+++ b/src/main/liveplugin/implementation/LivePluginProjectListener.kt
@@ -2,10 +2,11 @@ package liveplugin.implementation
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManagerListener
+import kotlinx.coroutines.runBlocking
 import liveplugin.implementation.pluginrunner.PluginRunner.Companion.unloadPlugins
 
 class LivePluginProjectListener : ProjectManagerListener {
-    override fun projectClosing(project: Project) {
+    override fun projectClosing(project: Project) = runBlocking {
         unloadPlugins(readLivePlugins(project))
     }
 }

--- a/src/main/liveplugin/implementation/LivePluginProjectPostStartupActivity.kt
+++ b/src/main/liveplugin/implementation/LivePluginProjectPostStartupActivity.kt
@@ -1,0 +1,29 @@
+package liveplugin.implementation
+
+import com.intellij.ide.impl.isTrusted
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.Presentation
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+import liveplugin.implementation.common.MapDataContext
+import liveplugin.implementation.common.livePluginNotificationGroup
+import liveplugin.implementation.pluginrunner.PluginRunner.Companion.runPlugins
+
+class LivePluginProjectPostStartupActivity : ProjectActivity {
+    override suspend fun execute(project: Project) {
+        if (!Settings.instance.runProjectSpecificPlugins) return
+        @Suppress("UnstableApiUsage")
+        if (!project.isTrusted()) {
+            val message = "Skipped execution of project specific plugins because the project is not trusted."
+            livePluginNotificationGroup.createNotification(title = "Live plugin", message, NotificationType.INFORMATION).notify(project)
+            return
+        }
+
+        val dataContext = MapDataContext(mapOf(CommonDataKeys.PROJECT.name to project))
+        val dummyEvent = AnActionEvent(null, dataContext, "", Presentation(), ActionManager.getInstance(), 0)
+        runPlugins(readLivePlugins(project), dummyEvent)
+    }
+}

--- a/src/main/liveplugin/implementation/ProjectPluginsReader.kt
+++ b/src/main/liveplugin/implementation/ProjectPluginsReader.kt
@@ -1,9 +1,28 @@
 package liveplugin.implementation
 
+import com.intellij.openapi.application.readAction
+import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.modules
+import com.intellij.openapi.project.rootManager
+import com.intellij.openapi.vfs.findFileOrDirectory
+import liveplugin.implementation.LivePluginPaths.livePluginsProjectDirName
 import liveplugin.implementation.common.toFilePath
 
-fun readLivePlugins(project: Project): List<LivePlugin> {
-    val projectPath = project.basePath?.toFilePath() ?: return emptyList()
-    return (projectPath + LivePluginPaths.livePluginsProjectDirName).listFiles().toLivePlugins()
+suspend fun readLivePlugins(project: Project): List<LivePlugin> {
+    return project.modules.flatMap { module ->
+        readLivePlugins(module)
+    }
+}
+
+suspend fun readLivePlugins(module: Module): List<LivePlugin> {
+    return module.rootManager.contentRoots
+        .mapNotNull { root ->
+            readAction {
+                root.findFileOrDirectory(livePluginsProjectDirName)?.takeIf { it.isDirectory }
+            }
+        }
+        .flatMap {
+            it.toFilePath().listFiles().toLivePlugins()
+        }
 }

--- a/src/main/liveplugin/implementation/ProjectPluginsReader.kt
+++ b/src/main/liveplugin/implementation/ProjectPluginsReader.kt
@@ -1,0 +1,9 @@
+package liveplugin.implementation
+
+import com.intellij.openapi.project.Project
+import liveplugin.implementation.common.toFilePath
+
+fun readLivePlugins(project: Project): List<LivePlugin> {
+    val projectPath = project.basePath?.toFilePath() ?: return emptyList()
+    return (projectPath + LivePluginPaths.livePluginsProjectDirName).listFiles().toLivePlugins()
+}


### PR DESCRIPTION
Before: only first module plugins were loaded.
After: plugins from all modules are loaded.

Also refactored out usage of deprecated method `projectOpened`.